### PR TITLE
Enable for use in extensions

### DIFF
--- a/Hydrant.xcodeproj/project.pbxproj
+++ b/Hydrant.xcodeproj/project.pbxproj
@@ -1718,6 +1718,7 @@
 		1F5447221B13A0EC003C1FFC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1749,6 +1750,7 @@
 		1F5447231B13A0EC003C1FFC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1830,6 +1832,7 @@
 		1F5447401B13A0F6003C1FFC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -1860,6 +1863,7 @@
 		1F5447411B13A0F6003C1FFC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
Hey Jeff! Long time, no see!

Just a quick pull request to make this not show a warning when using the dynamic framework with an extension.

Also, if you could do a release after this, then we could not pin our cartfile on some random sha.

Thanks!
- Rachel and Kai.