### PR TITLE
Parse non-ASCII URLs

### DIFF
--- a/Hydrant.xcodeproj/xcshareddata/xcschemes/Hydrant-iOS.xcscheme
+++ b/Hydrant.xcodeproj/xcshareddata/xcschemes/Hydrant-iOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0700"
-   version = "1.3">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Hydrant/Public/Formatters/HYDURLFormatter.m
+++ b/Hydrant/Public/Formatters/HYDURLFormatter.m
@@ -29,6 +29,10 @@
     }
 
     NSURL *url = [NSURL URLWithString:string];
+    if (!url) {
+        url = [NSURL URLWithString:[string stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+    }
+
     if (!url.scheme) {
         HYDSetObjectPointer(error, HYDLocalizedStringFormat(@"The value '%@' is not a valid URL", string));
         return NO;

--- a/Rakefile
+++ b/Rakefile
@@ -55,8 +55,8 @@ end
 desc 'Runs iOS 8 test bundles'
 task :specs_ios do
   Simulator.quit
-  xcbuild("test -scheme Hydrant-iOS -workspace Hydrant.xcworkspace -sdk iphonesimulator#{SDK_BUILD_VERSION} -destination 'name=iPhone 5s,OS=8.3' SYMROOT=#{BUILD_DIR.inspect}")
-  puts
+  xcbuild("test -scheme Hydrant-iOS -workspace Hydrant.xcworkspace -sdk iphonesimulator#{SDK_BUILD_VERSION} -destination 'name=iPhone 5s,OS=#{LATEST_SDK_VERSION}' SYMROOT=#{BUILD_DIR.inspect}")
+  puts 
 end
 
 desc 'Runs OSX test bundles'

--- a/Specs/Public/Formatters/HYDURLFormatterSpec.mm
+++ b/Specs/Public/Formatters/HYDURLFormatterSpec.mm
@@ -145,6 +145,21 @@ describe(@"HYDURLFormatter", ^{
             });
         });
 
+        context(@"when the url string is valid, but contains non-ascii characters", ^{
+            beforeEach(^{
+                sourceObject = @"https://www.mydomain.com/01-Coupé-400x300.png";
+            });
+
+            it(@"should return a percent-escaped url", ^{
+                parsedObject should equal([NSURL URLWithString:@"https://www.mydomain.com/01-Coup%C3%A9-400x300.png"]);
+            });
+
+            it(@"should not report an error", ^{
+                success should be_truthy;
+                errorDescription should be_nil;
+            });
+        });
+
         context(@"when not given a string", ^{
             beforeEach(^{
                 sourceObject = [NSNull null];


### PR DESCRIPTION
Naïve implementation that adds basic support for URLs that contain non-ascii characters such as diacritics (é, ö, etc…)

Also made a small change to the Rakefile to select a simulator with the most recent available version of iOS instead of hardcoding at 8.3.
